### PR TITLE
Add Zephyr PR for zscilib Pull Request #63

### DIFF
--- a/submanifests/optional.yaml
+++ b/submanifests/optional.yaml
@@ -60,7 +60,7 @@ manifest:
         - optional
     - name: zscilib
       path: modules/lib/zscilib
-      revision: ee1b287d9dd07208d2cc52284240ac25bb66eae3
+      revision: pull/63/head
       remote: upstream
       groups:
         - optional


### PR DESCRIPTION
zscilib: add quaternion bootstrapping algorithm

This diff adds a top-level Zephyr PR for the zscilib quaternion enhancements described in detail here:
https://github.com/zephyrproject-rtos/zscilib/pull/63

Signed-off-by: Ismail Degani <deganii@gmail.com>